### PR TITLE
Update newpipe extractor to fix YouTube streams facing HTTP 403 error desugar, use desugaring library, mutidex & update dependencies

### DIFF
--- a/project/app/build.gradle
+++ b/project/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
             // suffix the app id and the app name with git branch name
             def workingBranch = getGitWorkingBranch()
-            def normalizedWorkingBranch = workingBranch.replaceAll("[^A-Za-z]+", "").toLowerCase()
+            def normalizedWorkingBranch = workingBranch.replaceFirst("^[^A-Za-z]+", "").replaceAll("[^0-9A-Za-z]+", "")
             if (normalizedWorkingBranch.isEmpty() || workingBranch == "master" || workingBranch == "dev") {
                 // default values when branch name could not be determined or is master or dev
                 applicationIdSuffix ".debug"
@@ -63,6 +63,9 @@ android {
         // Or, if you prefer, you can continue to check for errors in release builds,
         // but continue the build even when errors are found:
         abortOnError false
+        // suppress false warning ("Resource IDs will be non-final in Android Gradle Plugin version
+        // 5.0, avoid using them in switch case statements"), which affects only library projects
+        disable 'NonConstantResourceId'
     }
 
     compileOptions {
@@ -148,6 +151,7 @@ afterEvaluate {
 }
 
 dependencies {
+/** Desugaring **/
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
@@ -174,11 +178,16 @@ dependencies {
         exclude module: 'support-annotations'
     }
 
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:9ffdd0948b2ecd82655f5ff2a3e127b2b7695d5b'
+/** NewPipe libraries **/
 
+    implementation 'com.github.Jtfk:NewPipeExtractor-j8:0.22.7-j8'
     implementation "com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751"
+
+/** Third-party libraries **/
     implementation "org.jsoup:jsoup:1.13.1"
 
+    // HTTP client
+    //noinspection GradleDependency --> do not update okhttp beyond 3.12.x to keep supporting Android 4.4 users
     implementation "com.squareup.okhttp3:okhttp:3.12.13"
 
     implementation "com.google.android.exoplayer:exoplayer:${exoPlayerVersion}"

--- a/project/app/build.gradle
+++ b/project/app/build.gradle
@@ -11,7 +11,7 @@ android {
     defaultConfig {
         applicationId "org.schabi.newpipe"
         resValue "string", "app_name", "NewPipe"
-        minSdkVersion 24
+        minSdkVersion 19
         targetSdkVersion 29
         versionCode 953
         versionName "0.19.8"

--- a/project/app/build.gradle
+++ b/project/app/build.gradle
@@ -75,6 +75,10 @@ android {
         encoding 'utf-8'
     }
 
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
+
     // Required and used only by groupie
     androidExtensions {
         experimental = true

--- a/project/app/build.gradle
+++ b/project/app/build.gradle
@@ -16,6 +16,8 @@ android {
         versionCode 953
         versionName "0.19.8"
 
+        multiDexEnabled true
+
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
 
@@ -64,6 +66,10 @@ android {
     }
 
     compileOptions {
+
+        // Flag to enable support for the new language APIs for API<24
++        coreLibraryDesugaringEnabled true
+
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
         encoding 'utf-8'
@@ -81,14 +87,14 @@ android {
 
 ext {
     icepickVersion = '3.2.0'
-    checkstyleVersion = '8.32'
+    checkstyleVersion = '8.38'
     stethoVersion = '1.5.1'
-    leakCanaryVersion = '2.2'
-    exoPlayerVersion = '2.11.6'
+    leakCanaryVersion = '2.5'
+    exoPlayerVersion = '2.11.8'
     androidxLifecycleVersion = '2.2.0'
     androidxRoomVersion = '2.2.5'
     groupieVersion = '2.8.0'
-    markwonVersion = '4.3.1'
+    markwonVersion = '4.6.0'
 }
 
 configurations {
@@ -138,13 +144,14 @@ afterEvaluate {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation "frankiesardo:icepick:${icepickVersion}"
     kapt "frankiesardo:icepick-processor:${icepickVersion}"
 
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"
-    ktlint "com.pinterest:ktlint:0.35.0"
+    ktlint "com.pinterest:ktlint:0.40.0"
 
     debugImplementation "com.facebook.stetho:stetho:${stethoVersion}"
     debugImplementation "com.facebook.stetho:stetho-okhttp3:${stethoVersion}"
@@ -152,14 +159,14 @@ dependencies {
     debugImplementation "com.squareup.leakcanary:leakcanary-android:${leakCanaryVersion}"
     implementation "com.squareup.leakcanary:leakcanary-object-watcher-android:${leakCanaryVersion}"
 
-    debugImplementation "androidx.multidex:multidex:2.0.1"
+    implementation "androidx.multidex:multidex:2.0.1"
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.3.3'
 
     androidTestImplementation "androidx.test.ext:junit:1.1.1"
     androidTestImplementation "androidx.room:room-testing:${androidxRoomVersion}"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0", {
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0", {
         exclude module: 'support-annotations'
     }
 
@@ -168,7 +175,7 @@ dependencies {
     implementation "com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751"
     implementation "org.jsoup:jsoup:1.13.1"
 
-    implementation "com.squareup.okhttp3:okhttp:3.12.11"
+    implementation "com.squareup.okhttp3:okhttp:3.12.13"
 
     implementation "com.google.android.exoplayer:exoplayer:${exoPlayerVersion}"
     implementation "com.google.android.exoplayer:extension-mediasession:${exoPlayerVersion}"
@@ -206,7 +213,7 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
     implementation "com.jakewharton.rxbinding2:rxbinding:2.2.0"
 
-    implementation "org.ocpsoft.prettytime:prettytime:4.0.5.Final"
+    implementation "org.ocpsoft.prettytime:prettytime:5.0.6.Final"
 }
 
 static String getGitWorkingBranch() {

--- a/project/app/src/main/java/org/schabi/newpipe/App.java
+++ b/project/app/src/main/java/org/schabi/newpipe/App.java
@@ -1,7 +1,6 @@
 package org.schabi.newpipe;
 
 import android.annotation.TargetApi;
-import android.app.Application;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -10,6 +9,7 @@ import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.multidex.MultiDexApplication;
 import androidx.preference.PreferenceManager;
 
 import com.nostra13.universalimageloader.cache.memory.impl.LRULimitedMemoryCache;
@@ -63,7 +63,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class App extends Application {
+public class App extends MultiDexApplication {
     protected static final String TAG = App.class.toString();
     @SuppressWarnings("unchecked")
     private static final Class<? extends ReportSenderFactory>[]

--- a/project/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/project/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -95,7 +95,7 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
         streamUrl = item.getUrl();
 
         itemContentView.setLines(COMMENT_DEFAULT_LINES);
-        commentText = item.getCommentText();
+        commentText = item.getCommentText().getContent();
         itemContentView.setText(commentText);
         itemContentView.setOnTouchListener(CommentTextOnTouchListener.INSTANCE);
 


### PR DESCRIPTION
1.Enable support for core library desugaring
2. Use multidex for all build types
3. Update ExoPlayer, OkHttp to last compatible version, use Kotlin JDK8
4. Updates org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version to use jdk 8 as NewPipe Extractor requires minimum java 8
5. Allow numbers and uppercase letters in app package id
6. Update PrettyTime library to 5.0.6Final
7. Update checkstyle to 8.36.2
8. Lowers api to 19 (as above commits make it possible to use app on api 19 )
9. Latest commit updates to a modified version of the extractor (https://github.com/Jtfk/NewPipeExtractor-j8), which is based on v0.22.7 upstream with backports to support Java 8 version made by @Jtfk as upstream NewPipe extractor requires Java 11 to build since v0.22.5+

Notes:- Use of Desugar Library (desugar_jdk_libs) is essential as NewPipe Extractor Now on Java 8 demands it for supporting api less than 26 in apps which use This Extractor.
NewPipe Extractor Readme  https://github.com/TeamNewPipe/NewPipeExtractor#readme

Documentation on recommended usage of Library Desugaring is here
https://developer.android.com/studio/write/java8-support#library-desugaring